### PR TITLE
Implemented dynamic size

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,17 @@ opts = {
     anticonceal = true,
     -- Hide the text when in the Insert Mode.
     hide_on_insert = true,
-    -- Scale of the equation images, increase to prevent blurry images when increasing terminal
-    -- font, high values may produce aliased images.
-    scale = 1.0,
-}
+    -- Enable dynamic size for non-inline equations.
+    dynamic = true,
+    -- Configure the scale of dynamic-rendered equations.
+    dynamic_scale = 1.0,
 
+    -- Internal scale of the equation images, increase to prevent blurry images when increasing terminal
+    -- font, high values may produce aliased images.
+    -- WARNING: This do not affect how the images are displayed, only how many pixels are used to render them.
+    --          See `dynamic_scale` to modify the displayed size.
+    internal_scale = 1.0,
+}
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The plugin is currently at alpha, many features are planned for the next version
   - [ ] An API to generate equation images.
   - [ ] Render in floating windows
   - [ ] Render out-of-line
-  - [ ] Dynamic width and height
+  - [x] Dynamic width and height
   - [ ] Improve scale of images (may need to work with Kitty for this one)
   - [ ] Refactoring: LuaCATS annotations
   - [ ] Documentation

--- a/lua/mdmath/Equation.lua
+++ b/lua/mdmath/Equation.lua
@@ -7,6 +7,7 @@ local Processor = require'mdmath.Processor'
 local Image = require'mdmath.Image'
 local tracker = require'mdmath.tracker'
 local terminfo = require'mdmath.terminfo'
+local config = require'mdmath.config'.opts
 
 local Equation = util.class 'Equation'
 
@@ -146,7 +147,11 @@ function Equation:_init(bufnr, row, col, text)
     local flags, height
     if self.lines then
         height = #self.lines
-        flags = 1 -- dynamic
+        if config.dynamic then
+            flags = 1 -- dynamic
+        else
+            flags = 0
+        end
     else
         height = 1
         flags = 2 -- centered

--- a/lua/mdmath/Equation.lua
+++ b/lua/mdmath/Equation.lua
@@ -60,7 +60,6 @@ function Equation:_create(res, err)
             lines[i] = { rtext, len }
         end
 
-
         vim.schedule(function()
             if self.valid then
                 self.mark_id = marks.add(self.bufnr, self.pos[1], self.pos[2], {

--- a/lua/mdmath/Equation.lua
+++ b/lua/mdmath/Equation.lua
@@ -127,12 +127,19 @@ function Equation:_init(bufnr, row, col, text)
     local cell_width, cell_height = terminfo.cell_size()
 
     -- dynamic size for multiline equations
-    -- FIXME: dynamic size is not implemented yet in the JS side
-    local img_width = self.lines and (self.width * cell_width) or (self.width * cell_width)
-    local img_height = (self.lines and #self.lines or 1) * cell_height
+    local flags, img_width, img_height
+    if self.lines then
+        img_width = self.width * cell_width
+        img_height = #self.lines * cell_height
+        flags = 1 -- dynamic
+    else
+        img_width = self.width * cell_width
+        img_height = cell_height
+        flags = 2 -- centered
+    end
 
     local processor = Processor.from_bufnr(bufnr)
-    processor:request(self.equation, img_width, img_height, not self.lines, function(res, err)
+    processor:request(self.equation, img_width, img_height, flags, function(res, err)
         if self.valid then
             self:_create(res, err)
         end

--- a/lua/mdmath/Equation.lua
+++ b/lua/mdmath/Equation.lua
@@ -46,19 +46,20 @@ function Equation:_create(res, err)
         local padding_len = self.width > width and self.width - width or 0
         local padding = (' '):rep(padding_len)
 
+        local nlines = #self.lines
+
         local lines = {}
         for i, text in ipairs(texts) do
             local rtext = text .. padding
 
-            lines[i] = { rtext, self.lines[i]:len() }
+            -- add virtual lines
+            local len = i <= nlines
+                and self.lines[i]:len()
+                or -1
+
+            lines[i] = { rtext, len }
         end
 
-        if height > #self.lines then
-            for i = #self.lines + 1, height do
-                lines[i] = { padding, -1 } -- -1 means virtual line
-            end
-        end
-        lines[#lines + 1] = { 'teste', -1 } 
 
         vim.schedule(function()
             if self.valid then

--- a/lua/mdmath/Image.lua
+++ b/lua/mdmath/Image.lua
@@ -61,9 +61,7 @@ function Image.unicode_at(row, col)
     return '\u{10EEEE}' .. diacritics[row] .. diacritics[col]
 end
 
-local teste_imagem
 function Image:text()
-    teste_imagem = self
     local text = {}
     for row = 1, self.rows do
         local T = {}

--- a/lua/mdmath/Processor.lua
+++ b/lua/mdmath/Processor.lua
@@ -62,9 +62,14 @@ function Processor:setForeground(color)
     self:_assert(not err, 'failed to set foreground: ', err)
 end
 
-function Processor:setScale(scale)
-    local code, err = self.pipes[0]:write(string.format("0:scale:%.2f:", scale))
-    self:_assert(not err, 'failed to set scale: ', err)
+function Processor:setInternalScale(scale)
+    local code, err = self.pipes[0]:write(string.format("0:iscale:%.2f:", scale))
+    self:_assert(not err, 'failed to set internal scale: ', err)
+end
+
+function Processor:setDynamicScale(scale)
+    local code, err = self.pipes[0]:write(string.format("0:dscale:%.2f:", scale))
+    self:_assert(not err, 'failed to set dynamic scale: ', err)
 end
 
 function Processor:request(data, cell_width, cell_height, width, height, flags, callback)
@@ -214,7 +219,8 @@ function Processor:_init()
     self:_listen()
 
     self:setForeground(config.foreground)
-    self:setScale(config.scale)
+    self:setInternalScale(config.internal_scale)
+    self:setDynamicScale(config.dynamic_scale)
 end
 
 function Processor:close()

--- a/lua/mdmath/Processor.lua
+++ b/lua/mdmath/Processor.lua
@@ -58,15 +58,18 @@ function Processor:setScale(scale)
     self:_assert(not err, 'failed to set scale: ', err)
 end
 
-function Processor:request(data, width, height, center, callback)
+function Processor:request(data, width, height, flags, callback)
+    -- flags: 0: none, 1: dynamic, 2: center, 3: dynamic + center
+    --        If dynamic, width and height are the terminal cell size
+    --        TODO: flags should be a enum
+
     local identifier = get_next_id()
     if self.callbacks[identifier] then
         return util.err_message('identifier already in use: ', identifier, ' (how the hell did this happen?)')
     end
     self.callbacks[identifier] = callback
 
-    center = center and 'true' or 'false'
-    local code, err = self.pipes[0]:write(string.format("%s:request:%d:%d:%s:%d:%s", identifier, width, height, center, #data, data))
+    local code, err = self.pipes[0]:write(string.format("%s:request:%d:%d:%d:%d:%s", identifier, width, height, flags, #data, data))
     self:_assert(not err, 'failed to request: ', err)
 end
 

--- a/lua/mdmath/config.lua
+++ b/lua/mdmath/config.lua
@@ -8,9 +8,16 @@ local default_opts = {
     anticonceal = true,
     -- Hide the text when in the Insert Mode.
     hide_on_insert = true,
-    -- Scale of the equation images, increase to prevent blurry images when increasing terminal
+    -- Enable dynamic size for non-inline equations.
+    dynamic = true,
+    -- Configure the scale of dynamic-rendered equations.
+    dynamic_scale = 1.0,
+
+    -- Internal scale of the equation images, increase to prevent blurry images when increasing terminal
     -- font, high values may produce aliased images.
-    scale = 1.0,
+    -- WARNING: This do not affect how the images are displayed, only how many pixels are used to render them.
+    --          See `dynamic_scale` to modify the displayed size.
+    internal_scale = 1.0,
 }
 
 local _opts = nil

--- a/lua/mdmath/config.lua
+++ b/lua/mdmath/config.lua
@@ -57,6 +57,9 @@ function M.validate()
         foreground = {opts.foreground, 'string'},
         anticonceal = {opts.anticonceal, 'boolean'},
         hide_on_insert = {opts.hide_on_insert, 'boolean'},
+        dynamic = {opts.dynamic, 'boolean'},
+        dynamic_scale = {opts.dynamic_scale, 'number'},
+        internal_scale = {opts.internal_scale, 'number'},
     }
 
     opts.foreground = require'mdmath.util'.hl_as_hex(opts.foreground)
@@ -71,7 +74,6 @@ function M.validate()
         vim.schedule(function()
             vim.notify('mdmath.nvim: `scale` option was removed, check `dynamic_scale` and `internal_scale`.', vim.log.levels.WARN)
         end)
-        opts.dynamic_scale = opts.scale
     end
 
     M.validated = true

--- a/lua/mdmath/config.lua
+++ b/lua/mdmath/config.lua
@@ -67,6 +67,13 @@ function M.validate()
         end,
     })
 
+    if opts.scale then
+        vim.schedule(function()
+            vim.notify('mdmath.nvim: `scale` option was removed, check `dynamic_scale` and `internal_scale`.', vim.log.levels.WARN)
+        end)
+        opts.dynamic_scale = opts.scale
+    end
+
     M.validated = true
     rawset(M, 'opts', opts)
 end

--- a/lua/mdmath/marks.lua
+++ b/lua/mdmath/marks.lua
@@ -1,3 +1,5 @@
+-- TODO: This code needs to be basically rewritten. It's a mess.
+
 local vim = vim
 local util = require'mdmath.util'
 local hl = require'mdmath.highlight-colors'
@@ -15,18 +17,22 @@ function Mark:_init(bufnr, row, col, opts)
     self.bufnr = bufnr
     self.opts = opts
     self.visible = false
+    self.extmark_ids = {}
+    self.render_visible = false
 
     -- FIX: Currently, lines that are smaller than the current line doesn't override the
     --      text below it. Although this is not intended, I don't think it's worth fixing it now.
     if opts.lines then
-        self.num_lines = #opts.lines
+        self.total_lines = #opts.lines
 
         self.lengths = {}
         for _, line in ipairs(opts.lines) do
             local length = line[2]
-            table.insert(self.lengths, length)
+            if length >= 0 then
+                table.insert(self.lengths, length)
+            end
         end
-
+        self.num_lines = #self.lengths
     else
         self.num_lines = 1
         self.lengths = { opts.text[2] }
@@ -72,21 +78,12 @@ function Mark:contains(row, col)
     return true
 end
 
-function Mark:_redraw()
-    local row = self.pos[1]
-    nvim._redraw({
-        buf = self.bufnr,
-        range = { row, row + self.num_lines },
-    })
-end
-
 function Mark:set_visible(visible)
     if self.visible == visible then
         return
     end
 
     self.visible = visible
-    self:_redraw()
 end
 
 local Buffer = util.class 'Buffer'
@@ -118,7 +115,14 @@ end
 function Buffer:remove(id)
     local mark = self.marks[id]
     if mark then
-        mark:set_visible(false)
+        for _, id in ipairs(mark.extmark_ids) do
+            nvim.buf_del_extmark(self.bufnr, ns, id)
+        end
+        mark.extmark_ids = {}
+
+        mark.visible = false
+        mark.render_visible = false
+
         mark.pos:cancel()
         self.marks[id] = nil
     end
@@ -220,56 +224,126 @@ do
 end
 
 -- TODO: This can be done once instead of every redraw
-local function opts2extmark(opts)
+local function opts2extmark(opts, row, col)
     if opts.lines then
         local extmarks = {}
         for _, line in ipairs(opts.lines) do
-            table.insert(extmarks, {
-                virt_text = { { line[1], opts.color } },
-                virt_text_pos = 'overlay',
-                virt_text_hide = true,
-                ephemeral = true,
-                undo_restore = false,
-            })
+            if line[2] < 0 then
+                local data = {
+                    virt_lines = { { { line[1], opts.color } } },
+                    ephemeral = false,
+                    undo_restore = false,
+                }
+                table.insert(extmarks, {
+                    data = data,
+                    row = row - 1,
+                    col = col,
+                })
+            else
+                local data = {
+                    virt_text = { { line[1], opts.color } },
+                    virt_text_pos = 'overlay',
+                    virt_text_hide = true,
+                    ephemeral = false,
+                    undo_restore = false,
+                }
+                table.insert(extmarks, {
+                    data = data,
+                    row = row,
+                    col = col,
+                })
+                row = row + 1
+            end
+            col = 0 -- reset col for next line
         end
         return extmarks, true
     else
-        return {
+        local data = {
             virt_text = { { opts.text[1], opts.color } },
             virt_text_pos = opts.text_pos,
             virt_text_hide = true,
-            ephemeral = true,
+            ephemeral = false,
             undo_restore = false,
-        }, false
+        }
+        return { {
+            data = data,
+            row = row,
+            col = col
+        } }, false
     end
 end
 
-function Mark:_draw()
-    local extmarks, lines = opts2extmark(self.opts)
+local function create_empty_virtual(opts, row)
+    if not opts.lines then
+        return nil
+    end
+
+    local virtual = 0
+    for _, line in ipairs(opts.lines) do
+        if line[2] >= 0 then
+            row = row + 1
+        else
+            virtual = virtual + 1
+        end
+    end
+
+    local lines = {}
+    for i = 1, virtual do
+        table.insert(lines, { { '', opts.color } })
+    end
+
+    local data = {
+        virt_lines = lines,
+        virt_lines_above = true,
+        ephemeral = false,
+        undo_restore = false,
+    }
+
+    return {
+        row = row,
+        data = data
+    }
+end
+
+function Mark:_draw(visible)
     local row, col = unpack(self.pos)
 
-    if lines then
-        for i, extmark in ipairs(extmarks) do
-            nvim.buf_set_extmark(self.bufnr, ns, row, col, extmark)
+    for _, id in ipairs(self.extmark_ids) do
+        nvim.buf_del_extmark(self.bufnr, ns, id)
+    end
+    self.extmark_ids = {}
 
-            row = row + 1
-            col = 0 -- reset col for next line
+    if not visible then
+        local virtual = create_empty_virtual(self.opts, row)
+        if virtual then
+            local id = nvim.buf_set_extmark(self.bufnr, ns, virtual.row, 0, virtual.data)
+            table.insert(self.extmark_ids, id)
         end
-    else
-        nvim.buf_set_extmark(self.bufnr, ns, row, col, extmarks)
+        return
+    end
+
+    local extmarks, lines = opts2extmark(self.opts, row, col)
+
+    for i, extmark in ipairs(extmarks) do
+        local id = nvim.buf_set_extmark(self.bufnr, ns, extmark.row, extmark.col, extmark.data)
+        table.insert(self.extmark_ids, id)
     end
 end
 
-function Mark:draw()
-    if self.visible then
-        local ok, err = pcall(self._draw, self)
+function Mark:flush(hidden)
+    local visible = not hidden and self.visible
+    if visible ~= self.render_visible then
+        local ok, err = pcall(self._draw, self, visible)
         if not ok then
             vim.schedule(function()
                 self:remove()
                 nvim.err_writeln('mdmath: failed to draw mark: ' .. err)
             end)
         end
+        self.render_visible = visible
+        return true
     end
+    return false
 end
 
 local M = {}
@@ -307,16 +381,21 @@ do
                 return false
             end
         end,
-        on_win = function(_, _, bufnr)
+        on_win = function(_, _, bufnr, top, bot)
             buffer = rawget(buffers, bufnr)
-            if not buffer or not buffer._show then
+            if not buffer then
                 return false
             end
+            top = top - 1
 
             for _, self in pairs(buffer.marks) do
-                self:draw()
-            end
+                local frow = self.pos[1]
+                local lrow = self.pos[1] + self.num_lines - 1
 
+                if top <= lrow and frow <= bot then
+                    self:flush(not buffer._show)
+                end
+            end
             return false
         end,
     })

--- a/mdmath-js/src/magick.js
+++ b/mdmath-js/src/magick.js
@@ -16,28 +16,88 @@ export const fileExists = (filename) => new Promise((resolve, reject) => {
     });
 });
 
-const convertBinary = new Promise(async (resolve) => {
+const magickBinary = new Promise(async (resolve) => {
     const paths = process.env.PATH.split(':');
 
     // ImageMagick v7
     for (const path of paths) {
         const magick = `${path}/magick`;
         if (await fileExists(magick)) {
-            return resolve(magick);
+            return resolve({
+                convert: magick,
+                identify: magick,
+                isV7: true
+            })
         }
     }
 
     // ImageMagick v6
+    let convertPath = null;
     for (const path of paths) {
-        const convert = `${path}/convert`;
-        if (await fileExists(convert)) {
-            return resolve(convert);
+        if (await fileExists(`${path}/convert`)) {
+            convertPath = path;
+            break;
+        }
+    }
+    if (convertPath === null) {
+        console.error('Failed to find ImageMagick v6/v7');
+        process.exit(1);
+    }
+
+    const convert = `${convertPath}/convert`;
+    let identify = `${convertPath}/identify`;
+
+    // Most of the time, the convert and identify binaries are in the same directory. So we will first
+    // try to find `identify` in the same directory as `convert`. If that fails, we will try to find
+    // another path that contains `identify`.
+    if (!await fileExists(identify)) {
+        identify = null;
+        for (const path of paths) {
+            if (await fileExists(`${path}/identify`)) {
+                identify = `${path}/identify`;
+                break;
+            }
+        }
+        if (identify === null) {
+            console.error('Failed to find ImageMagick v6/v7 (found convert, but not identify)');
+            process.exit(1);
         }
     }
 
-    console.error('Failed to find ImageMagick v6 or v7');
-    process.exit(1);
+    return resolve({
+        convert,
+        identify,
+        isV7: false
+    });
 });
+
+export async function svgDimensions(svg, {density} = {}) {
+    const magick = await magickBinary;
+
+    const args = ['-ping'];
+    if (density)
+        args.push('-density', density);
+    args.push('-format', '%w %h');
+    args.push('svg:-');
+    if (magick.isV7)
+        args.unshift('identify');
+
+    return new Promise((resolve, reject) => {
+        const identify = spawn(magick.identify, args);
+        let data = '';
+        identify.stdout.on('data', (chunk) => data += chunk);
+        identify.on('exit', (code) => {
+            // TODO: improve error handling
+            if (code !== 0)
+                return reject(new Error(`identify exited with code ${code}`));
+
+            const [width, height] = data.trim().split(' ').map(Number);
+            resolve({width, height});
+        });
+        identify.stdin.write(svg);
+        identify.stdin.end();
+    });
+}
 
 /**
  * Converts an SVG string to a PNG file with an optional size.
@@ -46,24 +106,33 @@ const convertBinary = new Promise(async (resolve) => {
  * @param {string} filename - The output PNG filename.
  * @param {number} width - The width of the output PNG image. (0 for dynamic)
  * @param {number} height - The height of the output PNG image.
- * @param {boolean} center - Whether to center the image.
+ * @param {Object} flags - Settings for the conversion.
+ * @param {boolean} flags.resize - Whether to resize the image.
+ * @param {boolean} flags.center - Whether to center the image.
+ * @param {number?} flags.density - The density of the image.
  * @returns {Promise<{width: number, height: number}>} - The width and height of the output PNG image.
  */
-export async function svg2png(svg, filename, width, height, center = false) {
+export async function svg2png(svg, filename, width, height, flags) {
     const size = `${width}x${height}`;
 
-    const args = ['-background', 'none', '-size', size, 'svg:-'];
-    if (center)
+    const args = ['-background', 'none'];
+    if (flags.resize)
+        args.push('-size', flags.size);
+    if (flags.density)
+        args.push('-density', flags.density);
+    args.push('svg:-');
+    if (flags.center)
         args.push('-gravity', 'Center');
     else
         args.push('-gravity', 'West');
+    args.push('-extent', size);
+    args.push(`png:${filename}`);
 
-    args.push('-extent', size, `png:${filename}`);
-
-    const convertBin = await convertBinary;
+    const magick = await magickBinary;
     return new Promise((resolve, reject) => {
-        const convert = spawn(convertBin, args);
+        const convert = spawn(magick.convert, args);
         convert.on('exit', (code) => {
+            // TODO: improve error handling
             if (code !== 0)
                 return reject(new Error(`convert exited with code ${code}`));
 

--- a/mdmath-js/src/magick.js
+++ b/mdmath-js/src/magick.js
@@ -118,7 +118,7 @@ export async function svg2png(svg, filename, width, height, flags) {
 
     const args = ['-background', 'none'];
     if (flags.resize)
-        args.push('-size', flags.size);
+        args.push('-size', size);
     if (flags.density)
         args.push('-density', flags.density);
     args.push('svg:-');

--- a/mdmath-js/src/processor.js
+++ b/mdmath-js/src/processor.js
@@ -173,7 +173,6 @@ async function processEquation(identifier, equation, cWidth, cHeight, width, hei
 
     try {
         await svg2png(svg, filename, iWidth, iHeight, {
-            resize: true,
             resize: !isDynamic,
             center: isCenter,
             density: density,

--- a/mdmath-js/src/processor.js
+++ b/mdmath-js/src/processor.js
@@ -151,11 +151,9 @@ async function processEquation(identifier, equation, cWidth, cHeight, width, hei
 
         const newWidth = (svgWidth / internalScale) / cWidth;
         const newHeight = (svgHeight / internalScale) / cHeight;
-        
+
         width = Math.ceil(newWidth);
         height = Math.ceil(newHeight);
-
-        sendNotification(`SVG width: ${svgWidth}, SVG height: ${svgHeight}`);
     }
 
     const hash = sha256Hash(equation).slice(0, 7);

--- a/mdmath-js/src/processor.js
+++ b/mdmath-js/src/processor.js
@@ -95,14 +95,11 @@ function writeError(identifier, error) {
   * @param {string} identifier
   * @param {string} equation
 */
-async function processEquation(identifier, width, height, center, equation) {
+async function processEquation(identifier, width, height, flags, equation) {
     if (!equation || equation.trim().length === 0)
         return writeError(identifier, 'Equation is empty')
 
-    width *= imageScale;
-    height *= imageScale;
-
-    const equation_key = `${equation}_${width}x${height}`;
+    const equation_key = `${equation}_${width}x${height}_${flags}`;
     if (equation_key in equationMap) {
         const equationObj = equationMap[equation_key];
         return write(identifier, equationObj.filename);
@@ -115,7 +112,12 @@ async function processEquation(identifier, width, height, center, equation) {
 
     const hash = sha256Hash(equation).slice(0, 7);
 
+    width *= imageScale;
+    height *= imageScale;
+    
+    const center = !!(flags & 2)
     const filename = `${IMG_DIR}/${hash}_${width}x${height}.png`;
+
     try {
         await svg2png(svg, filename, width, height, center);
     } catch (err) {
@@ -135,13 +137,14 @@ function processAll(request) {
             request.identifier,
             request.width,
             request.height,
-            request.center,
+            request.flags,
             request.data
         );
     } else if (request.type === 'fgcolor') {
         // FIXME: Invalidate cache when color changes
         fgColor = request.color;
     } else if (request.type === 'scale') {
+        // FIXME: Invalidate cache when scale changes
         imageScale = request.scale;
     }
 }

--- a/mdmath-js/src/processor.js
+++ b/mdmath-js/src/processor.js
@@ -27,8 +27,7 @@ const svgCache = {};
 let fgColor = '#ff00ff';
 
 let internalScale = 1;
-
-const imgRatio = 0.1
+let dynamicScale = 1;
 
 let MathJax = undefined;
 
@@ -144,9 +143,8 @@ async function processEquation(identifier, equation, cWidth, cHeight, width, hei
         // Also this should be fast, since we can use `identify ping` to get the image without loading it.
         // TODO: Is this fast in ImageMagick v6 too?
         // TODO: Is there a better solution?
-        const constant = 10;
+        density = 10 * dynamicScale * cHeight * internalScale;
 
-        density = constant * cHeight * internalScale;
         const {width: svgWidth, height: svgHeight} = await svgDimensions(svg, {density: density});
 
         const newWidth = (svgWidth / internalScale) / cWidth;
@@ -193,11 +191,13 @@ function processAll(request) {
             request.height,
             request.flags
         );                                                                                                                                                               
-  7         // TODO: Display a warning if dimensions ar
     } else if (request.type === 'fgcolor') {
         // FIXME: Invalidate cache when color changes
         fgColor = request.color;
-    } else if (request.type === 'scale') {
+    } else if (request.type === 'dscale') {
+        // FIXME: Invalidate cache when scale changes
+        dynamicScale = request.scale;
+    } else if (request.type === 'iscale') {
         // FIXME: Invalidate cache when scale changes
         internalScale = request.scale;
     }

--- a/mdmath-js/src/processor.js
+++ b/mdmath-js/src/processor.js
@@ -145,7 +145,14 @@ async function processEquation(identifier, equation, cWidth, cHeight, width, hei
         // TODO: Is there a better solution?
         density = 10 * dynamicScale * cHeight * internalScale;
 
-        const {width: svgWidth, height: svgHeight} = await svgDimensions(svg, {density: density});
+        let svgWidth, svgHeight;
+        try {
+            const {width, height} = await svgDimensions(svg, {density: density});
+            svgWidth = width;
+            svgHeight = height;
+        } catch (err) {
+            return writeError(identifier, 'svgDimensions: ' + err.message);
+        }
 
         const newWidth = (svgWidth / internalScale) / cWidth;
         const newHeight = (svgHeight / internalScale) / cHeight;
@@ -172,7 +179,7 @@ async function processEquation(identifier, equation, cWidth, cHeight, width, hei
             density: density,
         });
     } catch (err) {
-        return writeError(identifier, 'System: ' + err.message);
+        return writeError(identifier, 'svg2png: ' + err.message);
     }
 
     const equationObj = {equation, filename, width, height};

--- a/mdmath-js/src/processor.js
+++ b/mdmath-js/src/processor.js
@@ -150,8 +150,10 @@ async function processEquation(identifier, equation, cWidth, cHeight, width, hei
         const newWidth = (svgWidth / internalScale) / cWidth;
         const newHeight = (svgHeight / internalScale) / cHeight;
 
-        width = Math.ceil(newWidth);
-        height = Math.ceil(newHeight);
+        // If the image is smaller than the cell, it's better to keep the original size, so
+        // ImageMagick can center it properly.
+        width = Math.max(width, Math.ceil(newWidth));
+        height = Math.max(height, Math.ceil(newHeight));
     }
 
     const hash = sha256Hash(equation).slice(0, 7);

--- a/mdmath-js/src/reader.js
+++ b/mdmath-js/src/reader.js
@@ -63,7 +63,7 @@ reader.listen = function(callback) {
                     color
                 };
                 callback(response);
-            } else if(type == 'scale') {
+            } else if(type == 'iscale' || type == 'dscale') {
                 const scale = await stream.readFloat();
 
                 const response = {

--- a/mdmath-js/src/reader.js
+++ b/mdmath-js/src/reader.js
@@ -23,11 +23,6 @@ const reader = {}
 
 reader.listen = function(callback) {
     const stream = makeAsyncStream(process.stdin, ':');
-    let identifier;
-    let width;
-    let height;
-    let center;
-    let length;
 
     async function loop() {
         while (await stream.waitReadable()) {
@@ -35,16 +30,12 @@ reader.listen = function(callback) {
             const type = await stream.readString();
             if (type == 'request') {
                 const width = await stream.readInt();
-
                 const height = await stream.readInt();
 
-                const center_ = await stream.readString();
-                if (center_ !== 'true' && center_ !== 'false') 
-                    response_fail(`Invalid center: ${center_}`);
-                const center = center_ === 'true';
+                // TODO: Flags should be a enum
+                const flags = await stream.readInt();
 
                 const length = await stream.readInt();
-
                 const data = await stream.readFixedString(length);
 
                 const response = {
@@ -52,7 +43,7 @@ reader.listen = function(callback) {
                     type,
                     width,
                     height,
-                    center,
+                    flags,
                     data
                 };
                 callback(response);

--- a/mdmath-js/src/reader.js
+++ b/mdmath-js/src/reader.js
@@ -29,11 +29,14 @@ reader.listen = function(callback) {
             const identifier = await stream.readString();
             const type = await stream.readString();
             if (type == 'request') {
-                const width = await stream.readInt();
-                const height = await stream.readInt();
-
                 // TODO: Flags should be a enum
                 const flags = await stream.readInt();
+
+                const cellWidth = await stream.readInt();
+                const width = await stream.readInt();
+
+                const cellHeight = await stream.readInt();
+                const height = await stream.readInt();
 
                 const length = await stream.readInt();
                 const data = await stream.readFixedString(length);
@@ -41,6 +44,8 @@ reader.listen = function(callback) {
                 const response = {
                     identifier,
                     type,
+                    cellWidth,
+                    cellHeight,
                     width,
                     height,
                     flags,


### PR DESCRIPTION
For equations that are not-inline, we can create virtual spaces to be able to render them in a greater.
This PR creates 2 new options:
  - `dynamic`: Enable dynamic size. (default: `true`)
  - `dynamic_scale`: Configure the scale of the non-inline images. (When `dynamic` is true) (default: `1.0`)

Fix issue #1.