### PR TITLE
Fixed images being empty/not rendering correctly in tmux.

### DIFF
--- a/lua/mdmath/Image.lua
+++ b/lua/mdmath/Image.lua
@@ -14,27 +14,36 @@ local function next_id()
     return id
 end
 
+local function tmux_escape(sequence)
+	return "\x1bPtmux;" .. sequence:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
+end
+
 local function kitty_send(params, payload)
-    if not params.q then
-        params.q = 2
-    end
+	if not params.q then
+		params.q = 2
+	end
 
-    local tbl = {}
+	local tbl = {}
 
-    for k, v in pairs(params) do
-        tbl[#tbl + 1] = tostring(k) .. '=' .. tostring(v)
-    end
+	for k, v in pairs(params) do
+		tbl[#tbl + 1] = tostring(k) .. "=" .. tostring(v)
+	end
 
-    params = table.concat(tbl, ',')
+	params = table.concat(tbl, ",")
 
-    local message
-    if payload ~= nil then
-        message = string.format('\x1b_G%s;%s\x1b\\', params, vim.base64.encode(payload))
-    else
-        message = string.format('\x1b_G%s\x1b\\', params)
-    end
+	local message
+	if payload ~= nil then
+		message = string.format("\x1b_G%s;%s\x1b\\", params, vim.base64.encode(payload))
+	else
+		message = string.format("\x1b_G%s\x1b\\", params)
+	end
 
-    stdout:write(message)
+	if os.getenv("TMUX") ~= "" then
+		local tmux_message = tmux_escape(message)
+		stdout:write(tmux_message)
+	else
+		stdout:write(message)
+	end
 end
 
 local Image = util.class 'Image'


### PR DESCRIPTION
Fixes #5.

Images are rendered through tmux with the addition of `tmux_escape`, which adds the tmux control sequence and reformats the sequence to ensure it's interpreted properly. Additionally, there is a check for the `$TMUX` environment variable in `kitty_send`. If the variable is set, it assumes the user is using tmux.

I have tested this with Kitty + tmux on macOS.

Please let me know if there is anything I need to change. Thank you!